### PR TITLE
Fix the get version step in on commit to main workflow

### DIFF
--- a/.github/workflows/on_commit_to_main.yml
+++ b/.github/workflows/on_commit_to_main.yml
@@ -34,6 +34,12 @@ jobs:
     name: "Create github release"
     runs-on: "ubuntu-latest"
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
       - name: Get release version
         run: |
           echo "VERSION=$(python setup.py --version)" >> $GITHUB_ENV

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = type_hint_checker
 description = Check that all python files have type hints
-version = 0.1.11
+version = 0.1.12
 author = Paulina Pacyna
 license = MIT
 url = https://github.com/PaulinaPacyna


### PR DESCRIPTION
* Fix the get version step in on commit to main workflow by @PaulinaPacyna in https://github.com/PaulinaPacyna/type-hint-checker/pull/24
